### PR TITLE
Enable HTTPS port mapping

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -12,6 +12,20 @@
   "contributors": [
     "Eduardo Antuña <eduadiez@gmail.com> (https://github.com/eduadiez)"
   ],
+  "exposable": [
+    {
+      "name:": "Nethermind JSON RPC",
+      "description": "JSON RPC endpoint for Nethermind Ethereum mainnet",
+      "serviceName": "nethermind",
+      "port": 8545
+    },
+    {
+      "name:": "Nethermind JSON RPC (WS)",
+      "description": "JSON RPC WebSocket endpoint for Nethermind Ethereum mainnet",
+      "serviceName": "nethermind",
+      "port": 8545
+    }
+  ],
   "upstreamRepo": "NethermindEth/nethermind",
   "upstreamArg": "UPSTREAM_VERSION",
   "categories": ["Blockchain"],

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -5,7 +5,7 @@
   "shortDescription": "Nethermind Ethereum client",
   "description": "Nethermind - The world’s fastest Ethereum .NET Client and P2P Data Marketplace for the decentralised future\nOur flagship .NET Core-based Ethereum client is all about performance and flexibility. We have built a lean, stable and feature-rich gateway to allow anyone, anywhere, to take part in the decentralised future.",
   "type": "service",
-  "architectures": ["linux/amd64"],
+  "architectures": ["linux/amd64", "linux/arm64"],
   "dependencies": {},
   "chain": "ethereum",
   "author": "DAppNode Association <admin@dappnode.io> (https://github.com/dappnode)",

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -5,7 +5,7 @@
   "shortDescription": "Nethermind Ethereum client",
   "description": "Nethermind - The world’s fastest Ethereum .NET Client and P2P Data Marketplace for the decentralised future\nOur flagship .NET Core-based Ethereum client is all about performance and flexibility. We have built a lean, stable and feature-rich gateway to allow anyone, anywhere, to take part in the decentralised future.",
   "type": "service",
-  "architectures": ["linux/amd64", "linux/arm64"],
+  "architectures": ["linux/amd64"],
   "dependencies": {},
   "chain": "ethereum",
   "author": "DAppNode Association <admin@dappnode.io> (https://github.com/dappnode)",
@@ -23,7 +23,7 @@
       "name": "Nethermind JSON RPC (WS)",
       "description": "JSON RPC WebSocket endpoint for Nethermind Ethereum mainnet",
       "serviceName": "nethermind",
-      "port": 8545
+      "port": 8546
     }
   ],
   "upstreamRepo": "NethermindEth/nethermind",

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -14,13 +14,13 @@
   ],
   "exposable": [
     {
-      "name:": "Nethermind JSON RPC",
+      "name": "Nethermind JSON RPC",
       "description": "JSON RPC endpoint for Nethermind Ethereum mainnet",
       "serviceName": "nethermind",
       "port": 8545
     },
     {
-      "name:": "Nethermind JSON RPC (WS)",
+      "name": "Nethermind JSON RPC (WS)",
       "description": "JSON RPC WebSocket endpoint for Nethermind Ethereum mainnet",
       "serviceName": "nethermind",
       "port": 8545


### PR DESCRIPTION
In accordance with [this DNP_DAPPMANAGER issue](https://github.com/dappnode/DNP_DAPPMANAGER/issues/968) I am proposing we pull the hardcoded HTTPS entries ([which, as of right now, aren't working anyway](https://github.com/dappnode/DAppNode/issues/449)) from the `DNP_DAPPMANAGER` into the Nethermind package and rename the `serviceName` to `nethermind` instead of `nethermind.public.dappnode.eth`.

I will also prepare a PR in the `DNP_DAPPMANAGER` repo to remove the hardcoded lines.
