### PR TITLE
Add security_opt docker feature

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
         UPSTREAM_VERSION: 1.13.1
     image: "nethermind.public.dappnode.eth:1.0.9"
     restart: unless-stopped
+    security_opt:
+      - "seccomp:unconfined"
     volumes:
       - "data:/data"
     environment:


### PR DESCRIPTION
From the 1.13.2 version onwards, we have this issue https://github.com/NethermindEth/nethermind/issues/4169# in dappnode when we try to install the latest version(1.13.2 and 1.13.3).
This flag added to the docker-compose is an important and risky change. This option
```
    security_opt:
      - "seccomp:unconfined"
```
This option in the docker-compose disables the security option set up by default, you can read more information at https://docs.docker.com/engine/security/seccomp/ . 
The origin of all these changes is the usage of an old version of docker and an updated version of ubuntu or debian jimmi.
When the docker version of the dappnode is updated, we should remove this option.
