### PR TITLE
Set up config mode by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     volumes:
       - "data:/data"
     environment:
+      MODE: normal
       NETHERMIND_CONFIG: mainnet
       NETHERMIND_SYNCCONFIG_FASTSYNC: "true"
       NETHERMIND_JSONRPCCONFIG_ENABLED: "true"

--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -37,7 +37,6 @@ fields:
       - "archive"
       - "advanced"
       - "custom"
-    required: true
 
   - id: DownloadBodiesInFastSync
     target:
@@ -113,7 +112,7 @@ fields:
     description: >-
       Total Difficulty of the pivot block for the Fast Blocks sync (not - this is total difficulty and not difficulty). default value: null
     if: { "mode": { "enum": ["advanced"] } }
-  
+
   - id: UseGethLimitsInFastBlocks
     target:
       type: environment


### PR DESCRIPTION
This PR set up the config mode to normal by default. So the user has not to interact every time he update or install the package.