### PR TITLE
Hardcoded p2p ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,7 @@ services:
       NETHERMIND_INITCONFIG_WEBSOCKETSENABLED: "true"
       EXTRA_OPTS: null
     ports:
-      - 30303/tcp
-      - 30303/udp
+      - "30305:30303"
       - 30304/tcp
       - 30304/udp
 volumes:


### PR DESCRIPTION
According to this issue https://github.com/dappnode/DAppNode/issues/457
We are selecting the host port for the client.