### PR TITLE
Fix url

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -30,7 +30,7 @@
   "upstreamArg": "UPSTREAM_VERSION",
   "categories": ["Blockchain"],
   "links": {
-    "endpoint": "http://nethermind.dappnode:8545",
+    "endpoint": "http://nethermind.public.dappnode:8545",
     "homepage": "https://github.com/dappnode/DAppNodePackage-nethermind#readme"
   },
   "repository": {


### PR DESCRIPTION
nethermind.dappnode:8545 does not work, its required nethermind.public.dappnode:8545 in prysm package the url is correct