### PR TITLE
Update Nethermind executable name

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ apt install -y curl
 JWT=$(cat $JWT_PATH)
 curl -X POST "http://my.dappnode/data-send?key=jwt&data=${JWT}"
 
-exec /nethermind/Nethermind.Runner \
+exec /nethermind/nethermind \
   --JsonRpc.Enabled=true \
   --JsonRpc.JwtSecretFile=${JWT_PATH} \
   --Init.BaseDbPath=/data \


### PR DESCRIPTION
We renamed the Nethermind executable from `Nethermind.Runner` to `nethermind`. This PR updates the Docker entry point accordingly.

To be merged once production images are updated with the abovementioned change.